### PR TITLE
Fix version label from 'snapsnot' to 'snapshot'

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -8,7 +8,7 @@ publisher:
   name: Agence du Numérique en Santé (ANS) - 2-10 Rue d'Oradour-sur-Glane, 75015 Paris
   url: https://esante.gouv.fr
 status: draft
-version: 0.1.0-snapsnot # shall conforms to Semantic Versioning https://fr.wiktionary.org/wiki/SemVer
+version: 0.1.0-snapshot # shall conforms to Semantic Versioning https://fr.wiktionary.org/wiki/SemVer
 fhirVersion: 4.0.1
 copyrightYear: 2020+
 releaseLabel: ci-build # le release label doit être conforme au cycle de vie de la doctrine du ci-sis


### PR DESCRIPTION
## Description des changements

* Corriger la version dans sushi-config : 0.1.0-snapsnot ==> 0.1.0-snapshot
## Preview

https://ansforge.github.io/interop-IG-document-core/fixbugversion/ig
