### PR TITLE
Implémentation de la logique "Data absent reason et empty reason" dans l'IG

### DIFF
--- a/input/fsh/RessourcesFHIRCorps/aliases.fsh
+++ b/input/fsh/RessourcesFHIRCorps/aliases.fsh
@@ -1,4 +1,5 @@
 // Extensions
+Alias: $data-absent-reason = http://hl7.org/fhir/StructureDefinition/data-absent-reason
 Alias: $ihe-ext-medication-productname = https://profiles.ihe.net/PHARM/MPD/StructureDefinition/ihe-ext-medication-productname
 Alias: $ihe-ext-medication-classification = https://profiles.ihe.net/PHARM/MPD/StructureDefinition/ihe-ext-medication-classification
 Alias: $ihe-ext-medication-characteristic = https://profiles.ihe.net/PHARM/MPD/StructureDefinition/ihe-ext-medication-characteristic

--- a/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
@@ -1,0 +1,40 @@
+Instance: example-allergy-intolerance-data-absent-reason
+InstanceOf: FRAllergyIntoleranceDocument
+Title: "Example - AllergyIntolerance avec Data Absent Reason"
+Description: """Exemple illustrant l'usage de l'extension `data-absent-reason` sur les éléments
+obligatoires de la ressource AllergyIntolerance dont la valeur est inconnue ou
+temporairement indisponible.
+
+Cas d'usage illustrés :
+- `code` (1..1) : l'agent allergique est inconnu → code `unknown`
+- `onsetPeriod.start` (1..1) : la date de début est temporairement indisponible → code `temp-unknown`
+- `reaction.manifestation` (1..*) : la manifestation clinique est inconnue → code `unknown`"""
+Usage: #example
+
+// L'identifiant de l'entrée
+* identifier[+].system = "urn:ietf:rfc:3986"
+* identifier[=].value = "urn:uuid:7f0e9c1a-3b2d-4e5f-8a6b-1c2d3e4f5a6b"
+
+// Statut clinique et de vérification
+* clinicalStatus = http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical#active "Active"
+* verificationStatus = http://terminology.hl7.org/CodeSystem/allergyintolerance-verification#unconfirmed "Unconfirmed"
+
+// Agent allergique (1..1)
+// L'agent allergique est inconnu → extension data-absent-reason avec code "unknown"
+* code.extension[+].url = $data-absent-reason
+* code.extension[=].valueCode = #unknown
+
+// Patient
+* patient.reference = "Patient/exemple-patient"
+* patient.display = "Exemple Patient"
+
+// Période d'apparition (onsetPeriod.start obligatoire 1..1)
+// La date de début est temporairement indisponible (patient inconscient au moment de la saisie)
+// → extension data-absent-reason avec code "temp-unknown"
+* onsetPeriod.start.extension[+].url = $data-absent-reason
+* onsetPeriod.start.extension[=].valueCode = #temp-unknown
+
+// Réaction (reaction.manifestation obligatoire 1..*)
+// La manifestation clinique est inconnue → extension data-absent-reason avec code "unknown"
+* reaction[+].manifestation[+].extension[+].url = $data-absent-reason
+* reaction[=].manifestation[=].extension[=].valueCode = #unknown

--- a/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
@@ -7,7 +7,6 @@ temporairement indisponible.
 
 Cas d'usage illustrés :
 - `code` : l'agent allergique est inconnu → code `unknown`
-- `onsetPeriod.start` : la date de début est temporairement indisponible → code `temp-unknown`
 - `reaction.manifestation` : la manifestation clinique est inconnue → code `unknown`"""
 Usage: #example
 
@@ -29,16 +28,11 @@ Usage: #example
 * patient.reference = "Patient/exemple-patient"
 * patient.display = "Exemple Patient"
 
-// Période d'apparition (onsetPeriod.start obligatoire 1..1)
-// La date de début est temporairement indisponible → extension data-absent-reason avec code "temp-unknown"
-* onsetPeriod.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
-* onsetPeriod.extension.valueCode = #temp-unknown
-* onsetPeriod.start.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
-* onsetPeriod.start.extension.valueCode = #temp-unknown
+// Date de début d'identification de l'allergie ou de l'intolérance
+* onsetPeriod.start = "2021-12-04"
 
 // Réaction (reaction.manifestation obligatoire 1..*)
 // La manifestation clinique est inconnue → extension data-absent-reason avec code "unknown"
-// manifestation.text permet au renderer HTML d'afficher une valeur lisible (pattern IPS)
 * reaction[+].manifestation[+].text = "Manifestation clinique inconnue"
 * reaction[=].manifestation[=].extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
 * reaction[=].manifestation[=].extension.valueCode = #unknown

--- a/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
@@ -31,6 +31,8 @@ Usage: #example
 
 // Période d'apparition (onsetPeriod.start obligatoire 1..1)
 // La date de début est temporairement indisponible → extension data-absent-reason avec code "temp-unknown"
+* onsetPeriod.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+* onsetPeriod.extension.valueCode = #temp-unknown
 * onsetPeriod.start.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
 * onsetPeriod.start.extension.valueCode = #temp-unknown
 

--- a/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
@@ -10,9 +10,8 @@ Cas d'usage illustrés :
 - `reaction.manifestation` : la manifestation clinique est inconnue → code `unknown`"""
 Usage: #example
 
-// L'identifiant de l'entrée
-* identifier[+].system = "urn:ietf:rfc:3986"
-* identifier[=].value = "urn:uuid:7f0e9c1a-3b2d-4e5f-8a6b-1c2d3e4f5a6b"
+// Identifiant de l'allergie ou de l'intolérance
+* identifier.value = "urn:uuid:7f0e9c1a-3b2d-4e5f-8a6b-1c2d3e4f5a6b"
 
 // Statut clinique et de vérification
 * clinicalStatus = http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical#active "Active"

--- a/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
@@ -6,10 +6,14 @@ obligatoires de la ressource AllergyIntolerance dont la valeur est inconnue ou
 temporairement indisponible.
 
 Cas d'usage illustrés :
-- `code` (1..1) : l'agent allergique est inconnu → code `unknown`
-- `onsetPeriod.start` (1..1) : la date de début est temporairement indisponible → code `temp-unknown`
-- `reaction.manifestation` (1..*) : la manifestation clinique est inconnue → code `unknown`"""
+- `code` : l'agent allergique est inconnu → code `unknown`
+- `onsetPeriod.start` : la date de début est temporairement indisponible → code `temp-unknown`
+- `reaction.manifestation` : la manifestation clinique est inconnue → code `unknown`"""
 Usage: #example
+
+// Narratif FHIR : contrôle l'affichage dans l'IG Publisher
+* text.status = #extensions
+* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Exemple d'usage de l'extension data-absent-reason sur une AllergyIntolerance</b></p><table class=\"grid\"><tr><th>Élément</th><th>Cardinalité</th><th>Valeur</th><th>Extension data-absent-reason</th></tr><tr><td><code>code</code></td><td>1..1</td><td><i>absente</i></td><td><code>unknown</code> — agent allergique inconnu</td></tr><tr><td><code>onsetPeriod.start</code></td><td>1..1</td><td><i>absente</i></td><td><code>temp-unknown</code> — date temporairement indisponible</td></tr><tr><td><code>reaction.manifestation</code></td><td>1..*</td><td><i>absente</i></td><td><code>unknown</code> — manifestation clinique inconnue</td></tr></table><blockquote><p><b>Règle</b> : pour un élément obligatoire (cardinalité 1..1 ou 1..*) dont la valeur est indisponible, utiliser l'extension <code>data-absent-reason</code> avec le code approprié du ValueSet <a href=\"https://hl7.org/fhir/R4/valueset-data-absent-reason.html\">data-absent-reason</a>.</p></blockquote></div>"
 
 // L'identifiant de l'entrée
 * identifier[+].system = "urn:ietf:rfc:3986"
@@ -21,20 +25,22 @@ Usage: #example
 
 // Agent allergique (1..1)
 // L'agent allergique est inconnu → extension data-absent-reason avec code "unknown"
-* code.extension[+].url = $data-absent-reason
-* code.extension[=].valueCode = #unknown
+* code.text = "Agent allergique inconnu"
+* code.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+* code.extension.valueCode = #unknown
 
 // Patient
 * patient.reference = "Patient/exemple-patient"
 * patient.display = "Exemple Patient"
 
 // Période d'apparition (onsetPeriod.start obligatoire 1..1)
-// La date de début est temporairement indisponible (patient inconscient au moment de la saisie)
-// → extension data-absent-reason avec code "temp-unknown"
-* onsetPeriod.start.extension[+].url = $data-absent-reason
-* onsetPeriod.start.extension[=].valueCode = #temp-unknown
+// La date de début est temporairement indisponible → extension data-absent-reason avec code "temp-unknown"
+* onsetPeriod.start.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+* onsetPeriod.start.extension.valueCode = #temp-unknown
 
 // Réaction (reaction.manifestation obligatoire 1..*)
 // La manifestation clinique est inconnue → extension data-absent-reason avec code "unknown"
-* reaction[+].manifestation[+].extension[+].url = $data-absent-reason
-* reaction[=].manifestation[=].extension[=].valueCode = #unknown
+// manifestation.text permet au renderer HTML d'afficher une valeur lisible (pattern IPS)
+* reaction[+].manifestation[+].text = "Manifestation clinique inconnue"
+* reaction[=].manifestation[=].extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+* reaction[=].manifestation[=].extension.valueCode = #unknown

--- a/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
@@ -11,10 +11,6 @@ Cas d'usage illustrés :
 - `reaction.manifestation` : la manifestation clinique est inconnue → code `unknown`"""
 Usage: #example
 
-// Narratif FHIR : contrôle l'affichage dans l'IG Publisher
-* text.status = #extensions
-* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Exemple d'usage de l'extension data-absent-reason sur une AllergyIntolerance</b></p><table class=\"grid\"><tr><th>Élément</th><th>Cardinalité</th><th>Valeur</th><th>Extension data-absent-reason</th></tr><tr><td><code>code</code></td><td>1..1</td><td><i>absente</i></td><td><code>unknown</code> — agent allergique inconnu</td></tr><tr><td><code>onsetPeriod.start</code></td><td>1..1</td><td><i>absente</i></td><td><code>temp-unknown</code> — date temporairement indisponible</td></tr><tr><td><code>reaction.manifestation</code></td><td>1..*</td><td><i>absente</i></td><td><code>unknown</code> — manifestation clinique inconnue</td></tr></table><blockquote><p><b>Règle</b> : pour un élément obligatoire (cardinalité 1..1 ou 1..*) dont la valeur est indisponible, utiliser l'extension <code>data-absent-reason</code> avec le code approprié du ValueSet <a href=\"https://hl7.org/fhir/R4/valueset-data-absent-reason.html\">data-absent-reason</a>.</p></blockquote></div>"
-
 // L'identifiant de l'entrée
 * identifier[+].system = "urn:ietf:rfc:3986"
 * identifier[=].value = "urn:uuid:7f0e9c1a-3b2d-4e5f-8a6b-1c2d3e4f5a6b"

--- a/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRAllergyIntoleranceDocumentExample.fsh
@@ -12,6 +12,7 @@ Usage: #example
 
 // Identifiant de l'allergie ou de l'intolérance
 * identifier.value = "urn:uuid:7f0e9c1a-3b2d-4e5f-8a6b-1c2d3e4f5a6b"
+* identifier.system = "urn:ietf:rfc:3986"
 
 // Statut clinique et de vérification
 * clinicalStatus = http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical#active "Active"

--- a/input/fsh/RessourcesFHIRCorps/instances/FRProcedureDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRProcedureDocumentExample.fsh
@@ -28,7 +28,7 @@ Usage: #example
 // Code de l'acte (liaison extensible)
 // L'acte réalisé est inconnu → extension data-absent-reason avec code "unknown"
 // La liaison extensible autorise l'usage de data-absent-reason en l'absence de code applicable.
-* code.text = "Acte réalisé inconnu"
+* code.text = "Acte réalisé inconnu : utilisation de l'extension data-absent-reason avec code 'unknown'"
 * code.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
 * code.extension.valueCode = #unknown
 

--- a/input/fsh/RessourcesFHIRCorps/instances/FRProcedureDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRProcedureDocumentExample.fsh
@@ -5,33 +5,38 @@ Description: """Exemple illustrant l'usage de l'extension `data-absent-reason` s
 obligatoires de la ressource Procedure dont la valeur est inconnue ou temporairement indisponible.
 
 Cas d'usage illustrés :
-- `code` (1..1 MS) : l'acte est inconnu → extension `data-absent-reason` avec code `unknown`
+- `code` : l'acte est inconnu → extension `data-absent-reason` avec code `unknown`
   (liaison extensible → l'extension peut se substituer au codage)
-- `performedDateTime` (MS) : la date de l'acte est temporairement indisponible → extension `data-absent-reason` avec code `temp-unknown`
-- `status` (1..1 required) : le statut est inconnu → code d'exception `unknown` du ValueSet `event-status`
+- `performedDateTime` : la date de l'acte est temporairement indisponible → extension `data-absent-reason` avec code `temp-unknown`
+- `status` : le statut est inconnu → code d'exception `unknown` du ValueSet `event-status`
   (liaison required → on utilise directement le code d'exception du ValueSet, pas l'extension)"""
 Usage: #example
+
+// Narratif
+* text.status = #extensions
+* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Exemple d'usage de l'extension data-absent-reason sur une Procedure</b></p><table class=\"grid\"><tr><th>Élément</th><th>Cardinalité</th><th>Liaison ValueSet</th><th>Traitement</th></tr><tr><td><code>status</code></td><td>1..1</td><td><code>required</code> (event-status)</td><td>Code d'exception natif <code>unknown</code> — la liaison <i>required</i> interdit l'extension</td></tr><tr><td><code>code</code></td><td>1..1 MS</td><td><code>extensible</code></td><td>Extension <code>data-absent-reason</code> : <code>unknown</code> — acte réalisé inconnu</td></tr><tr><td><code>performedDateTime</code></td><td>MS</td><td>—</td><td>Extension <code>data-absent-reason</code> : <code>temp-unknown</code> — date temporairement indisponible</td></tr></table><blockquote><p><b>Règle</b> : pour une liaison <i>required</i>, utiliser un code d'exception du ValueSet. Pour une liaison <i>extensible</i> ou inférieure, utiliser l'extension <code>data-absent-reason</code>.</p></blockquote></div>"
 
 // Identification
 * identifier[+].system = "urn:ietf:rfc:3986"
 * identifier[=].value = "urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
-// Statut (1..1, liaison required)
+// Statut (liaison required)
 // Le statut est inconnu → code d'exception "unknown" du ValueSet event-status
-// La liaison required interdit l'usage de data-absent-reason ; on utilise le code d'exception natif.
+// VS required interdit l'usage de data-absent-reason ; on utilise le code d'exception natif sauf en cas d'indisponibilité dans le VS.
 * status = #unknown
 
 // Patient
 * subject.reference = "Patient/exemple-patient"
 * subject.display = "Exemple Patient"
 
-// Code de l'acte (1..1 MS, liaison extensible)
+// Code de l'acte (liaison extensible)
 // L'acte réalisé est inconnu → extension data-absent-reason avec code "unknown"
 // La liaison extensible autorise l'usage de data-absent-reason en l'absence de code applicable.
-* code.extension[+].url = $data-absent-reason
-* code.extension[=].valueCode = #unknown
+* code.text = "Acte réalisé inconnu"
+* code.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+* code.extension.valueCode = #unknown
 
-// Date de l'acte (MS, performedDateTime)
-// La date est temporairement indisponible (ex : acte ancien non documenté) → code "temp-unknown"
-* performedDateTime.extension[+].url = $data-absent-reason
-* performedDateTime.extension[=].valueCode = #temp-unknown
+// Date de l'acte (performedDateTime)
+// La date est temporairement indisponible → extension data-absent-reason avec code "temp-unknown"
+* performedDateTime.extension.url = "http://hl7.org/fhir/StructureDefinition/data-absent-reason"
+* performedDateTime.extension.valueCode = #temp-unknown

--- a/input/fsh/RessourcesFHIRCorps/instances/FRProcedureDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRProcedureDocumentExample.fsh
@@ -13,7 +13,8 @@ Cas d'usage illustrés :
 Usage: #example
 
 // Identification
-* identifier[=].value = "urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+* identifier.value = "urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+* identifier.system = "urn:ietf:rfc:3986"
 
 // Statut (liaison required)
 // Le statut est inconnu → code d'exception "unknown" du ValueSet event-status

--- a/input/fsh/RessourcesFHIRCorps/instances/FRProcedureDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRProcedureDocumentExample.fsh
@@ -1,0 +1,37 @@
+Instance: example-procedure-data-absent-reason
+InstanceOf: FRProcedureDocument
+Title: "Example - Procedure avec Data Absent Reason"
+Description: """Exemple illustrant l'usage de l'extension `data-absent-reason` sur les éléments
+obligatoires de la ressource Procedure dont la valeur est inconnue ou temporairement indisponible.
+
+Cas d'usage illustrés :
+- `code` (1..1 MS) : l'acte est inconnu → extension `data-absent-reason` avec code `unknown`
+  (liaison extensible → l'extension peut se substituer au codage)
+- `performedDateTime` (MS) : la date de l'acte est temporairement indisponible → extension `data-absent-reason` avec code `temp-unknown`
+- `status` (1..1 required) : le statut est inconnu → code d'exception `unknown` du ValueSet `event-status`
+  (liaison required → on utilise directement le code d'exception du ValueSet, pas l'extension)"""
+Usage: #example
+
+// Identification
+* identifier[+].system = "urn:ietf:rfc:3986"
+* identifier[=].value = "urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+// Statut (1..1, liaison required)
+// Le statut est inconnu → code d'exception "unknown" du ValueSet event-status
+// La liaison required interdit l'usage de data-absent-reason ; on utilise le code d'exception natif.
+* status = #unknown
+
+// Patient
+* subject.reference = "Patient/exemple-patient"
+* subject.display = "Exemple Patient"
+
+// Code de l'acte (1..1 MS, liaison extensible)
+// L'acte réalisé est inconnu → extension data-absent-reason avec code "unknown"
+// La liaison extensible autorise l'usage de data-absent-reason en l'absence de code applicable.
+* code.extension[+].url = $data-absent-reason
+* code.extension[=].valueCode = #unknown
+
+// Date de l'acte (MS, performedDateTime)
+// La date est temporairement indisponible (ex : acte ancien non documenté) → code "temp-unknown"
+* performedDateTime.extension[+].url = $data-absent-reason
+* performedDateTime.extension[=].valueCode = #temp-unknown

--- a/input/fsh/RessourcesFHIRCorps/instances/FRProcedureDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRProcedureDocumentExample.fsh
@@ -12,10 +12,6 @@ Cas d'usage illustrés :
   (liaison required → on utilise directement le code d'exception du ValueSet, pas l'extension)"""
 Usage: #example
 
-// Narratif
-* text.status = #extensions
-* text.div = "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>Exemple d'usage de l'extension data-absent-reason sur une Procedure</b></p><table class=\"grid\"><tr><th>Élément</th><th>Cardinalité</th><th>Liaison ValueSet</th><th>Traitement</th></tr><tr><td><code>status</code></td><td>1..1</td><td><code>required</code> (event-status)</td><td>Code d'exception natif <code>unknown</code> — la liaison <i>required</i> interdit l'extension</td></tr><tr><td><code>code</code></td><td>1..1 MS</td><td><code>extensible</code></td><td>Extension <code>data-absent-reason</code> : <code>unknown</code> — acte réalisé inconnu</td></tr><tr><td><code>performedDateTime</code></td><td>MS</td><td>—</td><td>Extension <code>data-absent-reason</code> : <code>temp-unknown</code> — date temporairement indisponible</td></tr></table><blockquote><p><b>Règle</b> : pour une liaison <i>required</i>, utiliser un code d'exception du ValueSet. Pour une liaison <i>extensible</i> ou inférieure, utiliser l'extension <code>data-absent-reason</code>.</p></blockquote></div>"
-
 // Identification
 * identifier[+].system = "urn:ietf:rfc:3986"
 * identifier[=].value = "urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890"

--- a/input/fsh/RessourcesFHIRCorps/instances/FRProcedureDocumentExample.fsh
+++ b/input/fsh/RessourcesFHIRCorps/instances/FRProcedureDocumentExample.fsh
@@ -13,7 +13,6 @@ Cas d'usage illustrés :
 Usage: #example
 
 // Identification
-* identifier[+].system = "urn:ietf:rfc:3986"
 * identifier[=].value = "urn:uuid:a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 
 // Statut (liaison required)

--- a/input/fsh/RessourcesFHIRCorps/profils/FRAllergyIntoleranceDocument.fsh
+++ b/input/fsh/RessourcesFHIRCorps/profils/FRAllergyIntoleranceDocument.fsh
@@ -12,9 +12,6 @@ Description: "FRAllergyIntoleranceDocument est un profil utilisé pourdécrire u
 * type MS
 * type ^short = "Type d'allergie ou d'intolérance"
 * type from FRValueSetAllergyInoleranceTypeDocument (required)
-* type MS
-* type ^short = "Type d'allergie ou d'intolérance"
-* type from FRValueSetAllergyInoleranceTypeDocument (required)
 * code 1..1 MS
 * code ^short = "agent allergique"
 * code from FRValueSetAllergyCodeDocument (extensible)

--- a/input/pagecontent/ressourcesFHIR-struc-gen.md
+++ b/input/pagecontent/ressourcesFHIR-struc-gen.md
@@ -152,13 +152,13 @@ La norme FHIR permet d’indiquer de façon optionnelle le rattachement d'une se
 Chaque entrée d'un document peut avoir un **subject**. Si l'entrée ne contient pas de subject, l’entrée concerne la personne indiquée dans l'élément **Composition.section.focus** de la section. Si la section ne contient pas d'élément **Composition.section.focus**, la section concerne la personne indiquée dans l'élément **subject** du document.
 C’est le principe de propagation du contexte et qui part du document vers les sections, sous-sections, entrées et sous-entrées emboitées.
 
-#### Gestion des sections vides : section.emptyReason
+#### Gestion des sections vides (pas d'information) : 
 
-En FHIR, l'élément `section.emptyReason` permet d'indiquer la raison pour laquelle une section est vide, c'est-à-dire qu'elle ne contient aucune entrée structurée. Son utilisation est conditionnée par le caractère obligatoire de la section dans le modèle de document.
+En FHIR, l'élément **section.emptyReason** permet d'indiquer la raison pour laquelle une section est vide, c'est-à-dire qu'elle ne contient aucune entrée structurée. Son utilisation est conditionnée par le caractère obligatoire de la section dans le modèle de document.
 
 ##### Sections obligatoires
 
-Pour les sections obligatoires (ex : Allergies et intolérances, Problèmes, Traitements), lorsqu'aucune entrée structurée n'est fournie, l'élément `section.emptyReason` **DOIT** être renseigné avec une valeur issue du JDV [`list-empty-reason`](http://hl7.org/fhir/ValueSet/list-empty-reason).
+Pour les sections obligatoires (ex : Allergies et intolérances, Problèmes, Traitements), lorsqu'aucune entrée structurée n'est fournie, l'élément **section.emptyReason** **DOIT** être renseigné avec une valeur issue du JDV [list-empty-reason](http://hl7.org/fhir/ValueSet/list-empty-reason).
 
 | Code | Libellé | Définition |
 |------|---------|------------|
@@ -171,15 +171,15 @@ Pour les sections obligatoires (ex : Allergies et intolérances, Problèmes, Tra
 
 ##### Sections facultatives
 
-Lorsqu'aucune donnée n'est disponible pour une section facultative, **le producteur ne doit pas créer la section**. L'élément `section.emptyReason` ne s'applique pas aux sections facultatives absentes.
+Lorsqu'aucune donnée n'est disponible pour une section facultative, **le producteur ne doit pas créer la section**. L'élément **section.emptyReason** ne s'applique pas aux sections facultatives absentes.
 
-> **En résumé** : `section.emptyReason` s'applique uniquement aux **sections obligatoires vides**. Pour les sections facultatives, l'absence de données se traduit simplement par l'absence de la section dans le document.
+> **En résumé** : *section.emptyReason* s'applique uniquement aux **sections obligatoires vides**. Pour les sections facultatives, l'absence de données se traduit simplement par l'absence de la section dans le document.
 
 ---
 
-### Gestion de l'absence de données au niveau des éléments
+### Gestion de l'absence de données au niveau des éléments (données manquantes)
 
-En FHIR, l'absence d'une valeur dans un élément structuré doit être gérée de manière explicite lorsque cela est requis. Les règles diffèrent selon la cardinalité de l'élément et selon que la donnée est codée ou non.
+En FHIR, l'absence d'une valeur dans un élément doit être gérée de manière explicite lorsque cela est **requis**. Les règles diffèrent selon la cardinalité de l'élément et selon que la donnée est codée ou non.
 
 #### Données optionnelles
 
@@ -237,18 +237,10 @@ Le ValueSet [data-absent-reason](https://hl7.org/fhir/R4/valueset-data-absent-re
   ...
 }
 ```
----
-
-> **Exemples complets** :
->
-> - L'instance [example-allergy-intolerance-data-absent-reason](AllergyIntolerance-example-allergy-intolerance-data-absent-reason.html) illustre l'usage de l'extension `data-absent-reason` sur les éléments obligatoires du profil [FRAllergyIntoleranceDocument](StructureDefinition-fr-allergie-intolerance-document.html) lorsque la valeur est inconnue ou temporairement indisponible.
-> - L'instance [example-procedure-data-absent-reason](Procedure-example-procedure-data-absent-reason.html) illustre les deux cas de figure sur le profil [FRProcedureDocument](StructureDefinition-fr-procedure-document.html) : extension `data-absent-reason` pour les liaisons non obligatoires (`code`, `performedDateTime`), et code d'exception natif (`unknown`) pour la liaison `required` (`status`).
-
----
 
 ##### Données obligatoires codées
 
-###### Liaison terminologique non obligatoire (`example`, `preferred` ou `extensible`)
+###### Données codées à partir d'un codeSystem/valueSet non obligatoire (`example`, `preferred` ou `extensible`)
 
 Si l'information n'est pas connue et qu'il existe dans la terminologie ou le ValueSet associé **un code d'exception spécifique**, utiliser ce code en priorité.
 
@@ -272,11 +264,22 @@ Dans les autres cas, utiliser l'extension [**Data Absent Reason**](http://hl7.or
 }
 ```
 
-###### Liaison terminologique obligatoire (`required`)
+###### Données codées à partir d'un codeSystem/valueSet (`required`)
 
 Si l'information n'est pas connue, **utiliser un code d'exception spécifique existant** dans la terminologie ou le ValueSet associé à la donnée. L'extension `data-absent-reason` ne peut pas être utilisée en substitution d'une valeur requise.
 
-Dans les autres cas, utiliser l'extension [**Data Absent Reason**](http://hl7.org/fhir/StructureDefinition/data-absent-reason)
+Si aucun code d'exception spécifique n'est disponible, utiliser l'extension [**Data Absent Reason**](http://hl7.org/fhir/StructureDefinition/data-absent-reason)
+
+---
+
+> **Exemples complets** :
+>
+> - L'instance [example-allergy-intolerance-data-absent-reason](AllergyIntolerance-example-allergy-intolerance-data-absent-reason.html) illustre l'usage de l'extension `data-absent-reason` sur les éléments obligatoires du profil [FRAllergyIntoleranceDocument](StructureDefinition-fr-allergie-intolerance-document.html) lorsque la valeur est inconnue ou temporairement indisponible.
+> - L'instance [example-procedure-data-absent-reason](Procedure-example-procedure-data-absent-reason.html) illustre les deux cas de figure sur le profil [FRProcedureDocument](StructureDefinition-fr-procedure-document.html) :
+>   - **extension `data-absent-reason`** pour les données codées à partir d'un codeSystem/valueSet non obligatoire (`example`, `preferred` ou `extensible`) : éléments `code`, `performedDateTime`
+>   - **code d'exception natif** du ValueSet `event-status`(`unknown`) pour les données codées à partir d'un codeSystem/valueSet obligatoire (`required`) : élément `status`
+
+---
 
 ### Conformité des documents FHIR
 

--- a/input/pagecontent/ressourcesFHIR-struc-gen.md
+++ b/input/pagecontent/ressourcesFHIR-struc-gen.md
@@ -279,8 +279,8 @@ En pratique, de nombreux ValueSets ou terminologies ne prévoient pas de code d'
 >
 > - L'instance [example-allergy-intolerance-data-absent-reason](AllergyIntolerance-example-allergy-intolerance-data-absent-reason.html) illustre l'usage de l'extension `data-absent-reason` sur les éléments obligatoires du profil [FRAllergyIntoleranceDocument](StructureDefinition-fr-allergie-intolerance-document.html) lorsque la valeur est inconnue ou temporairement indisponible.
 > - L'instance [example-procedure-data-absent-reason](Procedure-example-procedure-data-absent-reason.html) illustre les deux cas de figure sur le profil [FRProcedureDocument](StructureDefinition-fr-procedure-document.html) :
->   - **extension `data-absent-reason`** pour les données codées à partir d'un codeSystem/valueSet non obligatoire (`example`, `preferred` ou `extensible`) : éléments `code`, `performedDateTime`
->   - **code d'exception natif** du ValueSet `event-status`(`unknown`) pour les données codées à partir d'un codeSystem/valueSet obligatoire (`required`) : élément `status`
+>   - **`extension data-absent-reason`** pour les données codées à partir d'un codeSystem/valueSet non obligatoire (`example`, `preferred` ou `extensible`) : éléments `code`, `performedDateTime`
+>   - **`code d'exception natif`**  du ValueSet `event-status`(`unknown`) pour les données codées à partir d'un codeSystem/valueSet obligatoire (`required`) : élément `status`
 
 
 ### Conformité des documents FHIR

--- a/input/pagecontent/ressourcesFHIR-struc-gen.md
+++ b/input/pagecontent/ressourcesFHIR-struc-gen.md
@@ -152,6 +152,132 @@ La norme FHIR permet d’indiquer de façon optionnelle le rattachement d'une se
 Chaque entrée d'un document peut avoir un **subject**. Si l'entrée ne contient pas de subject, l’entrée concerne la personne indiquée dans l'élément **Composition.section.focus** de la section. Si la section ne contient pas d'élément **Composition.section.focus**, la section concerne la personne indiquée dans l'élément **subject** du document.
 C’est le principe de propagation du contexte et qui part du document vers les sections, sous-sections, entrées et sous-entrées emboitées.
 
+#### Gestion des sections vides : section.emptyReason
+
+En FHIR, l'élément `section.emptyReason` permet d'indiquer la raison pour laquelle une section est vide, c'est-à-dire qu'elle ne contient aucune entrée structurée. Son utilisation est conditionnée par le caractère obligatoire de la section dans le modèle de document.
+
+##### Sections obligatoires
+
+Pour les sections obligatoires (ex : Allergies et intolérances, Problèmes, Traitements), lorsqu'aucune entrée structurée n'est fournie, l'élément `section.emptyReason` **DOIT** être renseigné avec une valeur issue du JDV [`list-empty-reason`](http://hl7.org/fhir/ValueSet/list-empty-reason).
+
+| Code | Libellé | Définition |
+|------|---------|------------|
+| `nilknown` | Pas d'élément connu | Constatation clinique d'un professionnel de santé concluant, après investigation, à l'absence d'éléments connus pour cette donnée. **Cette valeur ne peut pas être fournie par défaut par un SIS en l'absence d'informations.** <br><br>Exemples :<br>- *Allergies* : le patient ou son représentant a déclaré n'avoir connaissance d'aucune allergie.<br>- *Médicaments* : le patient déclare ne prendre aucun médicament.<br>- *Diagnostics / problèmes* : le patient déclare qu'aucun événement connu ne doit être enregistré. |
+| `notasked` | Non demandé | Aucune investigation n'a été menée pour déterminer s'il existe des éléments pour cette liste. |
+| `withheld` | Non divulgué | Aucune information n'est fournie pour des raisons de confidentialité. Cela ne signifie pas nécessairement que le contenu est sensible ; il peut s'agir d'une décision personnelle du patient. |
+| `unavailable` | Indisponible | L'information est indisponible au moment de la production du document (ex : patient inconscient). |
+| `notstarted` | Non démarré | Les actions permettant d'obtenir cette information n'ont pas encore démarré. |
+| `closed` | Fermé | Cette liste est désormais fermée ou n'est plus pertinente ni utile. |
+
+##### Sections facultatives
+
+Lorsqu'aucune donnée n'est disponible pour une section facultative, **le producteur ne doit pas créer la section**. L'élément `section.emptyReason` ne s'applique pas aux sections facultatives absentes.
+
+> **En résumé** : `section.emptyReason` s'applique uniquement aux **sections obligatoires vides**. Pour les sections facultatives, l'absence de données se traduit simplement par l'absence de la section dans le document.
+
+---
+
+### Gestion de l'absence de données au niveau des éléments
+
+En FHIR, l'absence d'une valeur dans un élément structuré doit être gérée de manière explicite lorsque cela est requis. Les règles diffèrent selon la cardinalité de l'élément et selon que la donnée est codée ou non.
+
+#### Données optionnelles
+
+*(cardinalité `0..1` ou `0..*`)*
+
+Si l'information n'est pas disponible, quelle que soit la raison, **ne pas créer l'élément**. L'absence de l'élément dans la ressource est suffisante pour exprimer l'indisponibilité.
+
+#### Données obligatoires
+
+*(cardinalité `1..1` ou `1..*`)*
+
+Si l'information n'est pas disponible, **le motif de l'absence DOIT être précisé** via les mécanismes décrits ci-dessous.
+
+##### Données obligatoires non codées
+
+Utiliser l'extension [**Data Absent Reason**](http://hl7.org/fhir/StructureDefinition/data-absent-reason) avec :
+
+* `"url"` : `"http://hl7.org/fhir/StructureDefinition/data-absent-reason"`
+* `"valueCode"` : valeur issue du ValueSet [data-absent-reason](https://hl7.org/fhir/R4/valueset-data-absent-reason.html)
+
+Le ValueSet [data-absent-reason](https://hl7.org/fhir/R4/valueset-data-absent-reason.html) contient les valeurs suivantes :
+
+| Lvl | Code | Libellé | Définition |
+|-----|------|---------|------------|
+| 0 | `unknown` | Inconnu | Valeur inconnue. |
+| 1 | `asked-unknown` | Demandé - inconnu | Valeur demandée mais non connue. |
+| 1 | `temp-unknown` | Temporairement indisponible | Temporairement indisponible (mais pourrait ultérieurement être connue). |
+| 1 | `not-asked` | Non demandé | Valeur non demandée. |
+| 1 | `asked-declined` | Demandé - refus de réponse | Valeur demandée / refus de réponse. |
+| 0 | `masked` | Masqué | Valeur non disponible pour des raisons de sécurité, de confidentialité ou autres. |
+| 0 | `not-applicable` | Non applicable | Pas de valeur appropriée pour cet élément (par exemple, la date des dernières règles pour un homme). |
+| 0 | `unsupported` | Non supporté | Le système source ne gère pas cet élément. |
+| 0 | `as-text` | Voir narratif | Valeur fournie dans la partie narrative. |
+| 0 | `error` | Erreur | Valeur indisponible due à une erreur système ou de processus. |
+| 1 | `not-a-number` | Non numérique | La valeur numérique est indéfinie ou non représentable en raison d'une erreur de traitement des nombres à virgule flottante. |
+| 1 | `negative-infinity` | Borne inférieure infinie | La valeur numérique est excessivement basse et non représentable. |
+| 1 | `positive-infinity` | Borne supérieure infinie | La valeur numérique est excessivement élevée et non représentable. |
+| 0 | `not-performed` | Non effectué | La valeur n'est pas disponible car la procédure d'observation n'a pas été effectuée. |
+| 0 | `not-permitted` | Non autorisé | Cette valeur n'est pas autorisée dans ce contexte (par exemple, en raison des profils ou des types de données de base). |
+
+**Exemple** : dans une ressource `Procedure`, lorsque la date d'exécution (`performed[x]`) est inconnue :
+
+```json
+{
+  "resourceType": "Procedure",
+  ...
+  "_performedDateTime": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+        "valueCode": "unknown"
+      }
+    ]
+  },
+  ...
+}
+```
+---
+
+> **Exemples complets** :
+>
+> - L'instance [example-allergy-intolerance-data-absent-reason](AllergyIntolerance-example-allergy-intolerance-data-absent-reason.html) illustre l'usage de l'extension `data-absent-reason` sur les éléments obligatoires du profil [FRAllergyIntoleranceDocument](StructureDefinition-fr-allergie-intolerance-document.html) lorsque la valeur est inconnue ou temporairement indisponible.
+> - L'instance [example-procedure-data-absent-reason](Procedure-example-procedure-data-absent-reason.html) illustre les deux cas de figure sur le profil [FRProcedureDocument](StructureDefinition-fr-procedure-document.html) : extension `data-absent-reason` pour les liaisons non obligatoires (`code`, `performedDateTime`), et code d'exception natif (`unknown`) pour la liaison `required` (`status`).
+
+---
+
+##### Données obligatoires codées
+
+###### Liaison terminologique non obligatoire (`example`, `preferred` ou `extensible`)
+
+Si l'information n'est pas connue et qu'il existe dans la terminologie ou le ValueSet associé **un code d'exception spécifique**, utiliser ce code en priorité.
+
+> Exemple : code SNOMED CT `1287211007` — *"No information available"*.
+
+Dans les autres cas, utiliser l'extension [**Data Absent Reason**](http://hl7.org/fhir/StructureDefinition/data-absent-reason) avec la syntaxe suivante :
+
+```json
+{
+  "resourceType": "Observation",
+  ...
+  "code": {
+    "coding": [
+      {
+        "system": "http://terminology.hl7.org/CodeSystem/data-absent-reason",
+        "code": "masked"
+      }
+    ]
+  },
+  ...
+}
+```
+
+###### Liaison terminologique obligatoire (`required`)
+
+Si l'information n'est pas connue, **utiliser un code d'exception spécifique existant** dans la terminologie ou le ValueSet associé à la donnée. L'extension `data-absent-reason` ne peut pas être utilisée en substitution d'une valeur requise.
+
+Dans les autres cas, utiliser l'extension [**Data Absent Reason**](http://hl7.org/fhir/StructureDefinition/data-absent-reason)
+
 ### Conformité des documents FHIR
 
 Les documents au format FHIR définis dans le CI-SIS doivent être conformes :

--- a/input/pagecontent/ressourcesFHIR-struc-gen.md
+++ b/input/pagecontent/ressourcesFHIR-struc-gen.md
@@ -175,7 +175,6 @@ Lorsqu'aucune donnée n'est disponible pour une section facultative, **le produc
 
 > **En résumé** : *section.emptyReason* s'applique uniquement aux **sections obligatoires vides**. Pour les sections facultatives, l'absence de données se traduit simplement par l'absence de la section dans le document.
 
----
 
 ### Gestion de l'absence de données au niveau des éléments (données manquantes)
 
@@ -264,22 +263,25 @@ Dans les autres cas, utiliser l'extension [**Data Absent Reason**](http://hl7.or
 }
 ```
 
-###### Données codées à partir d'un codeSystem/valueSet (`required`)
+###### Données codées à partir d'un codeSystem/valueSet obligatoire (`required`)
 
-Si l'information n'est pas connue, **utiliser un code d'exception spécifique existant** dans la terminologie ou le ValueSet associé à la donnée. L'extension `data-absent-reason` ne peut pas être utilisée en substitution d'une valeur requise.
+> **Règle** : lorsqu'une donnée est absente, **utiliser le code d'exception du ValueSet ou de la terminologie associée**. C'est la règle de référence pour une liaison `required`.
 
-Si aucun code d'exception spécifique n'est disponible, utiliser l'extension [**Data Absent Reason**](http://hl7.org/fhir/StructureDefinition/data-absent-reason)
+En pratique, de nombreux ValueSets ou terminologies ne prévoient pas de code d'exception. Dans ce cas, faute de code applicable, **utiliser l'extension [Data Absent Reason](http://hl7.org/fhir/StructureDefinition/data-absent-reason)** comme mécanisme de repli.
 
----
+| Situation | Traitement |
+|---|---|
+| Le VS/terminologie contient un code d'exception (ex : `unknown` dans `event-status`) | Utiliser ce code d'exception |
+| Le VS/terminologie ne contient **aucun** code d'exception | Utiliser l'extension `data-absent-reason` |
 
-> **Exemples complets** :
+
+> **Exemples d'instances : Allergies et Procédures** :
 >
 > - L'instance [example-allergy-intolerance-data-absent-reason](AllergyIntolerance-example-allergy-intolerance-data-absent-reason.html) illustre l'usage de l'extension `data-absent-reason` sur les éléments obligatoires du profil [FRAllergyIntoleranceDocument](StructureDefinition-fr-allergie-intolerance-document.html) lorsque la valeur est inconnue ou temporairement indisponible.
 > - L'instance [example-procedure-data-absent-reason](Procedure-example-procedure-data-absent-reason.html) illustre les deux cas de figure sur le profil [FRProcedureDocument](StructureDefinition-fr-procedure-document.html) :
 >   - **extension `data-absent-reason`** pour les données codées à partir d'un codeSystem/valueSet non obligatoire (`example`, `preferred` ou `extensible`) : éléments `code`, `performedDateTime`
 >   - **code d'exception natif** du ValueSet `event-status`(`unknown`) pour les données codées à partir d'un codeSystem/valueSet obligatoire (`required`) : élément `status`
 
----
 
 ### Conformité des documents FHIR
 

--- a/input/pagecontent/ressourcesFHIR-struc-gen.md
+++ b/input/pagecontent/ressourcesFHIR-struc-gen.md
@@ -176,23 +176,23 @@ Lorsqu'aucune donnée n'est disponible pour une section facultative, **le produc
 > **En résumé** : *section.emptyReason* s'applique uniquement aux **sections obligatoires vides**. Pour les sections facultatives, l'absence de données se traduit simplement par l'absence de la section dans le document.
 
 
-### Gestion de l'absence de données au niveau des éléments (données manquantes)
+#### Gestion de l'absence de données au niveau des éléments (données manquantes)
 
 En FHIR, l'absence d'une valeur dans un élément doit être gérée de manière explicite lorsque cela est **requis**. Les règles diffèrent selon la cardinalité de l'élément et selon que la donnée est codée ou non.
 
-#### Données optionnelles
+##### Données optionnelles
 
 *(cardinalité `0..1` ou `0..*`)*
 
 Si l'information n'est pas disponible, quelle que soit la raison, **ne pas créer l'élément**. L'absence de l'élément dans la ressource est suffisante pour exprimer l'indisponibilité.
 
-#### Données obligatoires
+##### Données obligatoires
 
 *(cardinalité `1..1` ou `1..*`)*
 
 Si l'information n'est pas disponible, **le motif de l'absence DOIT être précisé** via les mécanismes décrits ci-dessous.
 
-##### Données obligatoires non codées
+###### Données obligatoires non codées
 
 Utiliser l'extension [**Data Absent Reason**](http://hl7.org/fhir/StructureDefinition/data-absent-reason) avec :
 
@@ -237,9 +237,9 @@ Le ValueSet [data-absent-reason](https://hl7.org/fhir/R4/valueset-data-absent-re
 }
 ```
 
-##### Données obligatoires codées
+###### Données obligatoires codées
 
-###### Données codées à partir d'un codeSystem/valueSet non obligatoire (`example`, `preferred` ou `extensible`)
+1. **Données codées à partir d'un codeSystem/valueSet non obligatoire** (`example`, `preferred` ou `extensible`)
 
 Si l'information n'est pas connue et qu'il existe dans la terminologie ou le ValueSet associé **un code d'exception spécifique**, utiliser ce code en priorité.
 
@@ -263,7 +263,7 @@ Dans les autres cas, utiliser l'extension [**Data Absent Reason**](http://hl7.or
 }
 ```
 
-###### Données codées à partir d'un codeSystem/valueSet obligatoire (`required`)
+2. **Données codées à partir d'un codeSystem/valueSet obligatoire** (`required`)
 
 > **Règle** : lorsqu'une donnée est absente, **utiliser le code d'exception du ValueSet ou de la terminologie associée**. C'est la règle de référence pour une liaison `required`.
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -721,6 +721,13 @@ groups:
       - FRPatientWithNonHumanSubjectLMCDAFHIR
       - FRNonHumanSubjectLMCDAFHIR
 
+  Exemples Data Absent Reason:
+    name: Exemples - Gestion de l'absence de données (Data Absent Reason)
+    description: Instances d'exemple illustrant l'usage de l'extension data-absent-reason sur les éléments obligatoires des profils FHIR corps du document.
+    resources:
+      - example-allergy-intolerance-data-absent-reason
+      - example-procedure-data-absent-reason
+
 resources: 
   Binary/BIO-CR-BIO-2024.01-Microbiologie-V1:
     name: BIO-CR-BIO_2024.01_Microbiologie_V1

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -721,13 +721,6 @@ groups:
       - FRPatientWithNonHumanSubjectLMCDAFHIR
       - FRNonHumanSubjectLMCDAFHIR
 
-  Exemples Data Absent Reason:
-    name: Exemples - Gestion de l'absence de données (Data Absent Reason)
-    description: Instances d'exemple illustrant l'usage de l'extension data-absent-reason sur les éléments obligatoires des profils FHIR corps du document.
-    resources:
-      - example-allergy-intolerance-data-absent-reason
-      - example-procedure-data-absent-reason
-
 resources: 
   Binary/BIO-CR-BIO-2024.01-Microbiologie-V1:
     name: BIO-CR-BIO_2024.01_Microbiologie_V1


### PR DESCRIPTION
## Description des changements

* Ajout des cas d'usage de data-absent-reason et empty-reason dans input/pagecontent/ressourcesFHIR-struc-gen.md
* Création de deux exemples (instances Allergie et Procédure) utilisant l'extension data-absent-reason en se basant sur des différents cas d'usage.

## Preview

https://ansforge.github.io/interop-IG-document-core/dataAbsentAndEmptyReason/ig
