### PR TITLE
Mise à jour des profils FHIR Suite aux issues remontés

### DIFF
--- a/input/fsh/RessourcesFHIRCorps/extensions/FRProcedureDifficultyExtension.fsh
+++ b/input/fsh/RessourcesFHIRCorps/extensions/FRProcedureDifficultyExtension.fsh
@@ -5,5 +5,5 @@ Description: "Extension permettant d'indiquer la difficulté perçue ou mesurée
 
 * ^context[+].type = #element
 * ^context[=].expression = "Procedure"
-* value[x] only CodeableConcept
+* value[x] only Reference(Observation)
 * value[x] ^short = "Difficulté de l'acte"

--- a/input/fsh/RessourcesFHIRCorps/extensions/FRProcedureDifficultyExtension.fsh
+++ b/input/fsh/RessourcesFHIRCorps/extensions/FRProcedureDifficultyExtension.fsh
@@ -5,5 +5,6 @@ Description: "Extension permettant d'indiquer la difficulté perçue ou mesurée
 
 * ^context[+].type = #element
 * ^context[=].expression = "Procedure"
-* value[x] only Reference(Observation)
+* value[x] only CodeableConcept
 * value[x] ^short = "Difficulté de l'acte"
+* valueCodeableConcept from https://smt.esante.gouv.fr/fhir/ValueSet/jdv-difficulte-cisis (example)

--- a/input/fsh/RessourcesFHIRCorps/profils/FRImagingStudyDocument.fsh
+++ b/input/fsh/RessourcesFHIRCorps/profils/FRImagingStudyDocument.fsh
@@ -26,6 +26,9 @@ L’examen est composé d'une ou de plusieurs séries d’images médicales."
 * basedOn[serviceRequestAccessionNumber] only Reference(FRServiceRequestDocument)
 * basedOn[serviceRequestAccessionNumber] ^short = "Référence à la demande d'examen contenant l'Accession Number"
 
+* numberOfSeries MS
+* numberOfSeries ^short = "Nombre de séries"
+
 * started MS
 * started ^short = "Date de l'acte"
 

--- a/input/fsh/RessourcesFHIRCorps/profils/FRProcedureDocument.fsh
+++ b/input/fsh/RessourcesFHIRCorps/profils/FRProcedureDocument.fsh
@@ -83,17 +83,17 @@ Pour les actes chirurgicaux inconnus, utiliser jdv-absent-or-unknown-procedure-c
 * recorder.extension[author].extension[type].valueCode = #AUT
 * recorder.extension[author].extension[actor].valueReference only Reference(FRPractitionerRoleDocument)
 
-//Réference interne à un DM (REFR)
+//Réference à un DM
 * usedReference MS
-* usedReference ^short = "Réference interne à un DM"
+* usedReference ^short = "Réference à un DM"
 * usedReference only Reference(Device)
 
-// Circonstances ayant décidé de l'acte à créer (COMP)
+// Rencontre associée à l'acte
 * encounter MS
-* encounter ^short = "Circonstances ayant décidé de l'acte"
+* encounter ^short = "Rencontre associée à l'acte"
 * encounter only Reference(FREncounterDocument)
 
-// Difficulté Observation / Scores Observation
+// Difficulté de l'acte
 * extension contains
     FRProcedureDifficultyExtension named difficulte 0..1 MS
-* extension[difficulte] ^short = "Référence vers une Observation représentant la difficulté"
+* extension[difficulte] ^short = "Difficulté de l'acte"

--- a/input/fsh/RessourcesFHIRCorps/profils/FRProcedureDocument.fsh
+++ b/input/fsh/RessourcesFHIRCorps/profils/FRProcedureDocument.fsh
@@ -11,9 +11,8 @@ Description: "FRProcedureDocument est un profil utilisé pour décrire un acte p
 * identifier ^short = "Identifiant"
 
 * partOf MS
-* partOf ^short = "Observation de score ou administration de médicament associée à l'acte (ex. : produit administré lors d'un acte d'imagerie)."
-* partOf only Reference(Observation or FRMedicationAdministrationDocument)
-
+* partOf ^short = "Événement associé : score (Cormack ou ASA), administration de médicament ou procédure associée à l’acte (ex. produit administré lors d’un acte d’imagerie)."
+* partOf only Reference(Observation or FRMedicationAdministrationDocument or FRProcedureDocument)
 * status MS
 * status ^short = "Statut de l'acte"
 

--- a/input/fsh/RessourcesFHIRCorps/profils/FRServiceRequestDocument.fsh
+++ b/input/fsh/RessourcesFHIRCorps/profils/FRServiceRequestDocument.fsh
@@ -19,17 +19,11 @@ Description: "FRServiceRequestDocument profil permet de porter des demandes d'ex
 * identifier[accessionNumber] ^short = "Accession Number de la demande d’examen d’imagerie"
 
 * intent MS
-* intent ^short = 
-"""
-Si la demande fait partie d'un plan de soins : 'INT = order'
-Si la demande est une proposition : 'PRP = proposal'
-Si la demande est un objectif à atteindre : 'GOL = plan'
-"""
+* intent ^short = "Intention de la demande : order, plan ou proposal"
+* obeys fr-invariant-intent
 * code 1..1 MS
-* code ^short = "Type de la demande"
-* code.coding ^short = "Type de la demande : Si aucun code n'est trouvé dans des terminologies existantes, utiliser le code : GEN-092.04.20 'Autre demande d’examen ou de suivi'"
-//Si aucun code n'est trouvé dans des terminologies existantes, utiliser le code : GEN-092.04.20
-//* code.concept = https://smt.esante.gouv.fr/fhir/CodeSystem/terminologie-cisis#GEN-092.04.20 "Autre demande d’examen ou de suivi"
+* code ^short = "Type de la demande : Si aucun code n'est trouvé dans des terminologies existantes, utiliser le code : GEN-092.04.20 'Autre demande d’examen ou de suivi'"
+//* code = $terminologie-cisis#GEN-092.04.20 "Autre demande d’examen ou de suivi"
 * occurrence[x] 1..1 MS
 * occurrence[x] ^short = "Date prévisionnelle de l'examen, du suivi, de l'objectif"
 * orderDetail 0..1 MS
@@ -66,11 +60,14 @@ Si la demande est un objectif à atteindre : 'GOL = plan'
     justificationDemande 1..1 MS
 
 // Slice 1 : Finalité de l’examen
-* note[finaliteExamen].text 1..1
 * note[finaliteExamen].text ^short = "Finalité de l’examen"
 * note[finaliteExamen] ^short = "Finalité de l’examen demandé"
 
 // Slice 2 : Justification de la demande
-* note[justificationDemande].text 1..1
 * note[justificationDemande].text ^short = "Justification de la demande d'examen"
 * note[justificationDemande] ^short = "Justification de la demande d’examen"
+
+Invariant: fr-invariant-intent
+Description: "L'intention doit être order, plan ou proposal."
+Expression: "intent = 'order' or intent = 'plan' or intent = 'proposal'"
+Severity: #error


### PR DESCRIPTION
## Description des changements

* Dans le profil FRServiceRequestDocument, nous avons : 
  - ajouté un invariant dans ServiceRequest.intent afin de résoudre l'issue #153 
  - modifié le short sur le code au lieu de code.coding #154
  - supprimé la cardinalité de note.text #155

* Dans l'extension FRProcedureDifficultyExtension nous avons ajouté un exemple de binding d'un VS difficulté de l'acte afin de résoudre les issues #157 et #158
* Dans le profil FRProcedureDocument nous avons,
   - remplacé "circonstance ayant décidé de l'acte" par "Rencontre associée à l'acte". #156
   - modifié le short de partOf afin d'ajouter des exemples des scores et ajouté dans partOf une référence vers FRProcedureDocument #160

## Preview

https://ansforge.github.io/interop-IG-document-core/issuesNRISS/ig
